### PR TITLE
fix: make fields in JavaScript options public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,8 @@ pub use sentry_rust_minidump as minidump;
 
 #[derive(Debug, Clone)]
 pub struct JavaScriptOptions {
-    inject: bool,
-    debug: bool,
+    pub inject: bool,
+    pub debug: bool,
 }
 
 impl Default for JavaScriptOptions {


### PR DESCRIPTION
I want to add some custom options but cannot set these fields right now. They should be public instead