### PR TITLE
fix: add additional check for ipc over http

### DIFF
--- a/js/index.ts
+++ b/js/index.ts
@@ -24,7 +24,7 @@ export function makeRendererTransport(options: BaseTransportOptions): Transport 
  */
 export function sendBreadcrumbToRust(breadcrumb: Breadcrumb): Breadcrumb | null {
   // Ignore IPC breadcrumbs otherwise we'll make an infinite loop
-  if (typeof breadcrumb.data?.url === 'string' && breadcrumb.data.url.startsWith('ipc://')) {
+  if (typeof breadcrumb.data?.url === 'string' && (breadcrumb.data.url.startsWith('ipc://') || breadcrumb.data.url.startsWith('http://ipc.localhost'))) {
     return null;
   }
 


### PR DESCRIPTION
I'm using this plugin in a Tauri app and noticed the UI completely froze after upgrading from v1 to v2. I see that you changed this file in https://github.com/timfish/sentry-tauri/pull/13/commits/8737623a910d964b59d14ad92406ceba4d27856b#diff-8e7ddf1b04e664328fd86034457d7b5297c4b3e35bc68fa091b215f9011de40a to check for ipc:// but it seems that (on Windows at least), the URL to check is indeed http://ipc.localhost. So adding this back in this PR which resolves my issue.