### PR TITLE
Disable `minidumper` on iOS since it's not compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,13 @@ exclude = ["/examples", "/node_modules", "/target"]
 [dependencies]
 base64 = "0.22"
 sentry = "0.35"
-sentry-rust-minidump = "0.9"
 serde = "1"
 tauri = "2"
 thiserror = "2"
 schemars = "0.8"
+
+[target.'cfg(not(target_os = "ios"))'.dependencies]
+sentry-rust-minidump = { version = "0.9" }
 
 [build-dependencies]
 tauri-plugin = { version = "2", features = ["build"] }

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ pub fn run() {
     ));
 
     // Caution! Everything before here runs in both app and crash reporter processes
+    #[cfg(not(target_os = "ios"))]
     let _guard = minidump::init(&client);
     // Everything after here runs in only the app process
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use tauri::{
 };
 
 pub use sentry;
+#[cfg(not(target_os = "ios"))]
 pub use sentry_rust_minidump as minidump;
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Minidump doesn't seem to have been implemented on `iOS` (see [EmbarkStudios/crash-handling/minidumper/src/ipc/client.rs#L27](https://github.com/EmbarkStudios/crash-handling/blob/e1f1241580d5204880fa47802b867b6bcb975f98/minidumper/src/ipc/client.rs#L27)).

```
error: unimplemented target platform
  --> /Users/adrien.pujol/.cargo/registry/src/index.crates.io-6f17d22bba15001f/minidumper-0.8.3/src/ipc/client.rs:52:17
   |
52 |                 compile_error!("unimplemented target platform");
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Therefore, I suggest disabling this dependency at build time with the following conditionals on compilation.