### PR TITLE
Expose Sentry features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,21 @@ version = "0.3.1"
 links = "tauri-plugin-sentry"
 exclude = ["/examples", "/node_modules", "/target"]
 
+[features]
+default = ["sentry/default"]
+anyhow = ["sentry/anyhow"]
+backtrace = ["sentry/backtrace"]
+contexts = ["sentry/contexts"]
+debug-images = ["sentry/debug-images"]
+native-tls = ["sentry/native-tls"]
+panic = ["sentry/panic"]
+reqwest = ["sentry/reqwest"]
+tracing = ["sentry/tracing"]
+transport = ["sentry/transport"]
+
 [dependencies]
 base64 = "0.22"
-sentry = "0.35"
+sentry = { version = "0.35", default-features = false }
 serde = "1"
 tauri = "2"
 thiserror = "2"


### PR DESCRIPTION
Expose sentry features so that they can be configured by the crate user. 

Two use cases:
1. Enable features which aren't enabled by default, see [doc](https://github.com/getsentry/sentry-rust/tree/master/sentry).
2. Disable some of these features, such as `debug-images`, which can be problematic in [some cases](https://github.com/getsentry/sentry-rust/issues/574#issuecomment-1534316787).